### PR TITLE
#786 feat: harden XFFTS receiver and non-blocking IERS preload

### DIFF
--- a/neclib/__init__.py
+++ b/neclib/__init__.py
@@ -1,35 +1,15 @@
 """Pure Python tools for NECST."""
 
 
-# Perform time-consuming downloads
-class _TimeConsumingTasks:
-    @staticmethod
-    def download_astropy_parameter_files():
-        """Will download finals2000A.all (3.4MB) and Leap_Second.dat (1.3KB)."""
-        from astropy.time import Time
-
-        Time.now().ut1
-
-
-import concurrent.futures  # noqa: E402
-
-executor = concurrent.futures.ThreadPoolExecutor()
-futures = [
-    executor.submit(getattr(_TimeConsumingTasks, func))
-    for func in dir(_TimeConsumingTasks)
-    if not func.startswith("_")
-]
-
-
 # Logger configuration
-import logging  # noqa: E402
+import logging as _logging  # noqa: E402
 
-rootLogger = logging.getLogger()
+rootLogger = _logging.getLogger()
 # Set minimum log level; not just for stream handler but for any handler attached.
 # Stream handler will selectively handle logs of INFO or higher levels, but DEBUG level
 # ones are not something you can completely ignore (may be recorded into log file)
-rootLogger.setLevel(logging.DEBUG)
-del logging, rootLogger
+rootLogger.setLevel(_logging.DEBUG)
+del rootLogger
 
 
 # Project version
@@ -38,6 +18,45 @@ from importlib.metadata import version  # noqa: E402
 __version__ = version("neclib")
 del version
 
+
+# Astropy IERS policy for observatory operation
+def _env_flag(name, default=False):
+    """Return a boolean from common environment-variable spellings."""
+
+    import os
+
+    value = os.environ.get(name)
+    if value is None:
+        return bool(default)
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _configure_astropy_iers_policy():
+    """Configure Astropy IERS behaviour for NECST operation.
+
+    The default is online-friendly: if the network is available, Astropy may
+    refresh stale IERS/leap-second data.  If the network is unavailable, NECST
+    should continue with local/cache/bundled data and warnings rather than fail
+    during node startup.
+
+    For deliberately offline operation, set
+    ``NECLIB_ASTROPY_IERS_AUTO_DOWNLOAD=0`` to use only the locally installed
+    astropy-iers-data/bundled tables.
+    """
+
+    from astropy.utils import iers
+
+    iers.conf.auto_download = _env_flag(
+        "NECLIB_ASTROPY_IERS_AUTO_DOWNLOAD", default=True
+    )
+
+    # If the available IERS data are stale or extrapolated, continue with
+    # warnings rather than aborting node startup.  Accuracy-sensitive code will
+    # still emit Astropy warnings at the actual UT1/coordinate conversion site.
+    iers.conf.iers_degraded_accuracy = "warn"
+
+
+_configure_astropy_iers_policy()
 
 # Subpackages
 # `devices` isn't included, since they can be OS-dependent hence verbose warnings
@@ -54,9 +73,186 @@ from .core import config, configure, get_logger  # noqa: F401, E402
 from .core.data_type import *  # noqa: F401, E402, F403
 from .core.exceptions import *  # noqa: F401, E402, F403
 
-# Wait for all background tasks to complete. Timeout should be sufficiently large,
-# otherwise attempt to download data files will be made every time importing `neclib`,
-# until it completes in restricted duration.
-concurrent.futures.wait(futures, timeout=None)
-executor.shutdown()
-del _TimeConsumingTasks, concurrent, executor, futures
+
+# Perform time-consuming Astropy IERS/leap-second preparation.
+#
+# The original implementation started this task at the beginning of
+# ``import neclib`` and waited for completion at the end.  That overlapped the
+# IERS/leap-second cache preparation with neclib imports, but it also allowed a
+# background ``astropy.time`` import to race with main-thread ``astropy.units``
+# or ``astropy.coordinates`` imports.  In Python 3.12 this can intermittently
+# leave Astropy in a partially initialised state during ROS node startup.
+#
+# Start the preload only after all neclib subpackages and aliases have been
+# imported.  At that point the Astropy import graph used by neclib has already
+# been initialised in the main thread, so the previous import-time race is
+# removed.  The network/cache work itself is intentionally not awaited: a dead
+# or absent network must not delay basic node startup.  Long-running nodes will
+# finish this warm-up in the background; short commands simply fall back to
+# Astropy's normal on-demand behaviour if they need UT1 immediately.
+def _start_astropy_iers_preload():
+    """Start best-effort Astropy IERS/leap-second preload in a daemon thread.
+
+    Importing ``astropy.time.Time`` is a hard dependency check and is done
+    synchronously.  The potentially slow ``Time.now().ut1`` part runs in the
+    background, may use the network when Astropy permits it, and reports
+    warnings/failures without preventing NECST commands from starting.
+    """
+
+    import importlib
+    import threading
+    import warnings
+
+    # Complete the Astropy import graph that neclib/necst commonly uses before
+    # the background thread starts.  This keeps the thread away from Astropy
+    # first-import paths while not touching any remote IERS data yet.
+    for module_name in (
+        "astropy.units",
+        "astropy.constants",
+        "astropy.coordinates",
+        "astropy.time",
+        "astropy.utils.iers",
+    ):
+        importlib.import_module(module_name)
+
+    from astropy.time import Time
+    from astropy.utils import iers
+
+    logger = _logging.getLogger(__name__)
+    auto_download = bool(iers.conf.auto_download)
+
+    def _worker():
+        download_notice_urls = set()
+
+        def _format_download_url(url):
+            try:
+                if hasattr(url, "full_url"):
+                    return str(url.full_url)
+                return str(url)
+            except Exception:
+                return "<unknown-url>"
+
+        def _notice_download(url):
+            text = _format_download_url(url)
+            if text in download_notice_urls:
+                return
+            download_notice_urls.add(text)
+            logger.warning(
+                "Astropy IERS/leap-second preload is downloading or "
+                "refreshing a remote data file: %s",
+                text,
+            )
+
+        try:
+            if auto_download:
+                logger.info(
+                    "Astropy IERS/leap-second background preload started; "
+                    "remote download warnings will be emitted only if Astropy "
+                    "actually opens a remote connection. NECST startup will "
+                    "not wait for this task."
+                )
+            else:
+                logger.info(
+                    "Astropy IERS/leap-second background preload started with "
+                    "auto_download disabled; local/cache/bundled tables only. "
+                    "NECST startup will not wait for this task."
+                )
+
+            # Astropy's IERS/leap-second refresh ultimately opens remote URLs
+            # through astropy.utils.data and/or urllib.  Patch only within this
+            # background preload so normal NECST code is not changed.  A warning
+            # is emitted when a real remote-open path is reached, not merely when
+            # Time.now().ut1 starts or when a cached table is used.
+            restore_actions = []
+            if auto_download:
+                import urllib.request as _urllib_request
+                import astropy.utils.data as _astropy_data
+
+                original_urlopen = _urllib_request.urlopen
+
+                def urlopen_with_notice(url, *args, **kwargs):
+                    _notice_download(url)
+                    return original_urlopen(url, *args, **kwargs)
+
+                _urllib_request.urlopen = urlopen_with_notice
+                restore_actions.append(
+                    lambda: setattr(_urllib_request, "urlopen", original_urlopen)
+                )
+
+                if getattr(_astropy_data, "urlopen", None) is original_urlopen:
+                    _astropy_data.urlopen = urlopen_with_notice
+                    restore_actions.append(
+                        lambda: setattr(_astropy_data, "urlopen", original_urlopen)
+                    )
+
+                original_download_from_source = getattr(
+                    _astropy_data, "_download_file_from_source", None
+                )
+                if callable(original_download_from_source):
+
+                    def download_from_source_with_notice(source_url, *args, **kwargs):
+                        _notice_download(source_url)
+                        return original_download_from_source(
+                            source_url, *args, **kwargs
+                        )
+
+                    _astropy_data._download_file_from_source = (
+                        download_from_source_with_notice
+                    )
+                    restore_actions.append(
+                        lambda: setattr(
+                            _astropy_data,
+                            "_download_file_from_source",
+                            original_download_from_source,
+                        )
+                    )
+
+            try:
+                with warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter("always")
+                    Time.now().ut1
+            finally:
+                for restore in reversed(restore_actions):
+                    restore()
+
+            for warning in caught:
+                logger.warning(
+                    "Astropy IERS/leap-second preload warning: %s: %s",
+                    warning.category.__name__,
+                    warning.message,
+                )
+            if download_notice_urls:
+                logger.info(
+                    "Astropy IERS/leap-second background preload finished "
+                    "after remote data access."
+                )
+            else:
+                logger.info(
+                    "Astropy IERS/leap-second background preload finished "
+                    "without remote data access."
+                )
+        except Exception:
+            # The preload is only a best-effort warm-up.  Keep NECST commands
+            # importable in offline observing environments; the actual Time/UT1
+            # or coordinate operation will warn/fail where it is required if the
+            # local data are too degraded for that operation.
+            logger.warning(
+                "Astropy IERS/leap-second preload failed in background; "
+                "NECST will continue, but UT1/coordinate conversions may warn "
+                "or fail when first used.",
+                exc_info=True,
+            )
+
+    thread = threading.Thread(
+        target=_worker,
+        name="neclib-astropy-iers-preload",
+        daemon=True,
+    )
+    thread.start()
+    return thread
+
+
+_astropy_iers_preload_thread = _start_astropy_iers_preload()
+
+
+del _start_astropy_iers_preload, _configure_astropy_iers_policy, _env_flag, _logging

--- a/neclib/__init__.py
+++ b/neclib/__init__.py
@@ -76,183 +76,116 @@ from .core.exceptions import *  # noqa: F401, E402, F403
 
 # Perform time-consuming Astropy IERS/leap-second preparation.
 #
-# The original implementation started this task at the beginning of
-# ``import neclib`` and waited for completion at the end.  That overlapped the
-# IERS/leap-second cache preparation with neclib imports, but it also allowed a
-# background ``astropy.time`` import to race with main-thread ``astropy.units``
-# or ``astropy.coordinates`` imports.  In Python 3.12 this can intermittently
-# leave Astropy in a partially initialised state during ROS node startup.
+# IMPORTANT:
+# This must not run in a Python thread inside the importing NECST process.
+# Antenna/device nodes may continue importing necst/neclib modules after
+# ``import neclib`` has returned, and a background in-process Astropy import can
+# still race with those later imports.  That race intermittently produced
+# ``ImportError: cannot import name 'Unit' from partially initialized module
+# 'astropy.units.core'`` during ROS node startup.
 #
-# Start the preload only after all neclib subpackages and aliases have been
-# imported.  At that point the Astropy import graph used by neclib has already
-# been initialised in the main thread, so the previous import-time race is
-# removed.  The network/cache work itself is intentionally not awaited: a dead
-# or absent network must not delay basic node startup.  Long-running nodes will
-# finish this warm-up in the background; short commands simply fall back to
-# Astropy's normal on-demand behaviour if they need UT1 immediately.
+# To keep node startup robust while still allowing online IERS/leap-second cache
+# refresh, the optional warm-up is now launched in a separate Python process.
+# The child process owns all Astropy imports used for the warm-up, so it cannot
+# corrupt the parent process' import state.  The parent does not wait for it.
 def _start_astropy_iers_preload():
-    """Start best-effort Astropy IERS/leap-second preload in a daemon thread.
+    """Start best-effort Astropy IERS/leap-second preload out-of-process.
 
-    Importing ``astropy.time.Time`` is a hard dependency check and is done
-    synchronously.  The potentially slow ``Time.now().ut1`` part runs in the
-    background, may use the network when Astropy permits it, and reports
-    warnings/failures without preventing NECST commands from starting.
+    The parent process only starts a detached helper process and never imports
+    ``astropy.time`` in a background thread.  This preserves the original
+    operational goal--do not block node startup on IERS network/cache work--but
+    removes the import-time race seen in Python 3.12.
+
+    Set ``NECLIB_ASTROPY_IERS_PRELOAD=0`` to disable this helper completely.
     """
 
-    import importlib
-    import threading
-    import warnings
-
-    # Complete the Astropy import graph that neclib/necst commonly uses before
-    # the background thread starts.  This keeps the thread away from Astropy
-    # first-import paths while not touching any remote IERS data yet.
-    for module_name in (
-        "astropy.units",
-        "astropy.constants",
-        "astropy.coordinates",
-        "astropy.time",
-        "astropy.utils.iers",
-    ):
-        importlib.import_module(module_name)
-
-    from astropy.time import Time
-    from astropy.utils import iers
+    import os
+    from pathlib import Path
+    import subprocess
+    import sys
+    import time
 
     logger = _logging.getLogger(__name__)
-    auto_download = bool(iers.conf.auto_download)
 
-    def _worker():
-        download_notice_urls = set()
+    if not _env_flag("NECLIB_ASTROPY_IERS_PRELOAD", default=True):
+        logger.info("Astropy IERS/leap-second preload helper is disabled.")
+        return None
 
-        def _format_download_url(url):
-            try:
-                if hasattr(url, "full_url"):
-                    return str(url.full_url)
-                return str(url)
-            except Exception:
-                return "<unknown-url>"
+    state_dir = Path(
+        os.environ.get("NECLIB_ASTROPY_IERS_PRELOAD_DIR", "~/.necst")
+    ).expanduser()
+    try:
+        state_dir.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        logger.warning(
+            "Could not create Astropy IERS preload state directory: %s",
+            state_dir,
+            exc_info=True,
+        )
+        return None
 
-        def _notice_download(url):
-            text = _format_download_url(url)
-            if text in download_notice_urls:
-                return
-            download_notice_urls.add(text)
-            logger.warning(
-                "Astropy IERS/leap-second preload is downloading or "
-                "refreshing a remote data file: %s",
-                text,
-            )
+    lock_path = state_dir / "astropy_iers_preload.lock"
+    log_path = state_dir / "astropy_iers_preload.log"
 
-        try:
-            if auto_download:
-                logger.info(
-                    "Astropy IERS/leap-second background preload started; "
-                    "remote download warnings will be emitted only if Astropy "
-                    "actually opens a remote connection. NECST startup will "
-                    "not wait for this task."
+    # Avoid spawning one network/cache refresh process per ROS node when many
+    # nodes start at the same time.  A stale lock older than 10 minutes is
+    # discarded.  This is only an optimisation; failure to create the lock must
+    # never prevent a NECST node from starting.
+    try:
+        if lock_path.exists():
+            age_s = time.time() - lock_path.stat().st_mtime
+            if age_s < 600:
+                logger.debug(
+                    "Astropy IERS preload helper already appears to be running: %s",
+                    lock_path,
                 )
-            else:
-                logger.info(
-                    "Astropy IERS/leap-second background preload started with "
-                    "auto_download disabled; local/cache/bundled tables only. "
-                    "NECST startup will not wait for this task."
-                )
+                return None
+            lock_path.unlink(missing_ok=True)
+        fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        with os.fdopen(fd, "w", encoding="utf-8") as lock:
+            lock.write(f"parent_pid={os.getpid()}\n")
+            lock.write(f"created_unix={time.time():.6f}\n")
+    except Exception:
+        logger.debug(
+            "Could not create Astropy IERS preload lock; skipping helper.",
+            exc_info=True,
+        )
+        return None
 
-            # Astropy's IERS/leap-second refresh ultimately opens remote URLs
-            # through astropy.utils.data and/or urllib.  Patch only within this
-            # background preload so normal NECST code is not changed.  A warning
-            # is emitted when a real remote-open path is reached, not merely when
-            # Time.now().ut1 starts or when a cached table is used.
-            restore_actions = []
-            if auto_download:
-                import urllib.request as _urllib_request
-                import astropy.utils.data as _astropy_data
+    child_code = '\nimport logging\nimport os\nfrom pathlib import Path\nimport warnings\n\nlock_path = os.environ.get("NECLIB_ASTROPY_IERS_PRELOAD_LOCK")\nlog_path = os.environ.get("NECLIB_ASTROPY_IERS_PRELOAD_LOG")\n\nlogger = logging.getLogger("neclib.astropy_iers_preload")\nlogger.setLevel(logging.INFO)\nformatter = logging.Formatter("[%(levelname)s] %(asctime)s %(name)s: %(message)s")\nstream = logging.StreamHandler()\nstream.setLevel(logging.WARNING)\nstream.setFormatter(formatter)\nlogger.addHandler(stream)\nif log_path:\n    try:\n        file_handler = logging.FileHandler(log_path, mode="a", encoding="utf-8")\n        file_handler.setLevel(logging.INFO)\n        file_handler.setFormatter(formatter)\n        logger.addHandler(file_handler)\n    except Exception:\n        logger.warning("Could not open preload log file: %s", log_path, exc_info=True)\n\n\ndef _env_flag(name, default=False):\n    value = os.environ.get(name)\n    if value is None:\n        return bool(default)\n    return value.strip().lower() in {"1", "true", "yes", "on"}\n\n\ndef _format_download_url(url):\n    try:\n        if hasattr(url, "full_url"):\n            return str(url.full_url)\n        return str(url)\n    except Exception:\n        return "<unknown-url>"\n\n\ndef main():\n    auto_download = _env_flag("NECLIB_ASTROPY_IERS_AUTO_DOWNLOAD", default=True)\n\n    from astropy.utils import iers\n\n    iers.conf.auto_download = auto_download\n    iers.conf.iers_degraded_accuracy = "warn"\n\n    download_notice_urls = set()\n\n    def _notice_download(url):\n        text = _format_download_url(url)\n        if text in download_notice_urls:\n            return\n        download_notice_urls.add(text)\n        logger.warning(\n            "Astropy IERS/leap-second preload is downloading or refreshing "\n            "a remote data file: %s",\n            text,\n        )\n\n    restore_actions = []\n    if auto_download:\n        import urllib.request as _urllib_request\n        import astropy.utils.data as _astropy_data\n\n        original_urlopen = _urllib_request.urlopen\n\n        def urlopen_with_notice(url, *args, **kwargs):\n            _notice_download(url)\n            return original_urlopen(url, *args, **kwargs)\n\n        _urllib_request.urlopen = urlopen_with_notice\n        restore_actions.append(lambda: setattr(_urllib_request, "urlopen", original_urlopen))\n\n        if getattr(_astropy_data, "urlopen", None) is original_urlopen:\n            _astropy_data.urlopen = urlopen_with_notice\n            restore_actions.append(lambda: setattr(_astropy_data, "urlopen", original_urlopen))\n\n        original_download_from_source = getattr(_astropy_data, "_download_file_from_source", None)\n        if callable(original_download_from_source):\n\n            def download_from_source_with_notice(source_url, *args, **kwargs):\n                _notice_download(source_url)\n                return original_download_from_source(source_url, *args, **kwargs)\n\n            _astropy_data._download_file_from_source = download_from_source_with_notice\n            restore_actions.append(\n                lambda: setattr(\n                    _astropy_data,\n                    "_download_file_from_source",\n                    original_download_from_source,\n                )\n            )\n\n    try:\n        from astropy.time import Time\n\n        if auto_download:\n            logger.info(\n                "Astropy IERS/leap-second preload helper started; remote "\n                "download warnings are emitted only if a remote connection is opened."\n            )\n        else:\n            logger.info(\n                "Astropy IERS/leap-second preload helper started with "\n                "auto_download disabled; local/cache/bundled tables only."\n            )\n        with warnings.catch_warnings(record=True) as caught:\n            warnings.simplefilter("always")\n            Time.now().ut1\n        for warning in caught:\n            logger.warning(\n                "Astropy IERS/leap-second preload warning: %s: %s",\n                warning.category.__name__,\n                warning.message,\n            )\n        if download_notice_urls:\n            logger.info("Astropy IERS/leap-second preload helper finished after remote data access.")\n        else:\n            logger.info("Astropy IERS/leap-second preload helper finished without remote data access.")\n    finally:\n        for restore in reversed(restore_actions):\n            try:\n                restore()\n            except Exception:\n                logger.debug("Failed to restore patched downloader", exc_info=True)\n\n\ntry:\n    main()\nexcept Exception:\n    logger.warning(\n        "Astropy IERS/leap-second preload helper failed; NECST parent process "\n        "continues and Astropy will use normal on-demand behaviour.",\n        exc_info=True,\n    )\nfinally:\n    if lock_path:\n        try:\n            Path(lock_path).unlink(missing_ok=True)\n        except Exception:\n            pass\n'
 
-                original_urlopen = _urllib_request.urlopen
+    env = os.environ.copy()
+    env["NECLIB_ASTROPY_IERS_PRELOAD_LOCK"] = str(lock_path)
+    env["NECLIB_ASTROPY_IERS_PRELOAD_LOG"] = str(log_path)
 
-                def urlopen_with_notice(url, *args, **kwargs):
-                    _notice_download(url)
-                    return original_urlopen(url, *args, **kwargs)
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, "-c", child_code],
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=None,
+            stderr=None,
+            close_fds=True,
+            start_new_session=True,
+        )
+    except Exception:
+        lock_path.unlink(missing_ok=True)
+        logger.warning(
+            "Failed to start Astropy IERS/leap-second preload helper process.",
+            exc_info=True,
+        )
+        return None
 
-                _urllib_request.urlopen = urlopen_with_notice
-                restore_actions.append(
-                    lambda: setattr(_urllib_request, "urlopen", original_urlopen)
-                )
-
-                if getattr(_astropy_data, "urlopen", None) is original_urlopen:
-                    _astropy_data.urlopen = urlopen_with_notice
-                    restore_actions.append(
-                        lambda: setattr(_astropy_data, "urlopen", original_urlopen)
-                    )
-
-                original_download_from_source = getattr(
-                    _astropy_data, "_download_file_from_source", None
-                )
-                if callable(original_download_from_source):
-
-                    def download_from_source_with_notice(source_url, *args, **kwargs):
-                        _notice_download(source_url)
-                        return original_download_from_source(
-                            source_url, *args, **kwargs
-                        )
-
-                    _astropy_data._download_file_from_source = (
-                        download_from_source_with_notice
-                    )
-                    restore_actions.append(
-                        lambda: setattr(
-                            _astropy_data,
-                            "_download_file_from_source",
-                            original_download_from_source,
-                        )
-                    )
-
-            try:
-                with warnings.catch_warnings(record=True) as caught:
-                    warnings.simplefilter("always")
-                    Time.now().ut1
-            finally:
-                for restore in reversed(restore_actions):
-                    restore()
-
-            for warning in caught:
-                logger.warning(
-                    "Astropy IERS/leap-second preload warning: %s: %s",
-                    warning.category.__name__,
-                    warning.message,
-                )
-            if download_notice_urls:
-                logger.info(
-                    "Astropy IERS/leap-second background preload finished "
-                    "after remote data access."
-                )
-            else:
-                logger.info(
-                    "Astropy IERS/leap-second background preload finished "
-                    "without remote data access."
-                )
-        except Exception:
-            # The preload is only a best-effort warm-up.  Keep NECST commands
-            # importable in offline observing environments; the actual Time/UT1
-            # or coordinate operation will warn/fail where it is required if the
-            # local data are too degraded for that operation.
-            logger.warning(
-                "Astropy IERS/leap-second preload failed in background; "
-                "NECST will continue, but UT1/coordinate conversions may warn "
-                "or fail when first used.",
-                exc_info=True,
-            )
-
-    thread = threading.Thread(
-        target=_worker,
-        name="neclib-astropy-iers-preload",
-        daemon=True,
+    logger.info(
+        "Started Astropy IERS/leap-second preload helper process pid=%s; "
+        "log=%s. NECST startup will not wait for it.",
+        proc.pid,
+        log_path,
     )
-    thread.start()
-    return thread
+    return proc
 
 
-_astropy_iers_preload_thread = _start_astropy_iers_preload()
+_astropy_iers_preload_process = _start_astropy_iers_preload()
 
 
 del _start_astropy_iers_preload, _configure_astropy_iers_policy, _env_flag, _logging

--- a/neclib/devices/spectrometer/xffts.py
+++ b/neclib/devices/spectrometer/xffts.py
@@ -1,9 +1,10 @@
+import inspect
 import queue
-import struct
+import socket
 import time
 import traceback
-from threading import Event, Thread
-from typing import Dict, List, Tuple
+from threading import Event, Lock, Thread
+from typing import Any, Dict, List, Tuple
 
 import xfftspy
 
@@ -65,20 +66,149 @@ class XFFTS(Spectrometer):
         self.data_port = self.Config.data_port
         self.synctime_us = self.Config.synctime_us
         self.bw_mhz = {int(k): v for k, v in self.Config.bw_MHz.items()}
+
+        # A blocking TCP recv must not prevent NECST abort/finalize from returning.
+        # Keep the default comfortably longer than the XFFTS sync interval, while
+        # still finite so that cable/server failures become visible.
+        self.data_timeout_sec = float(
+            getattr(
+                self.Config,
+                "data_timeout_sec",
+                max(5.0, 5.0 * float(self.synctime_us) / 1_000_000.0),
+            )
+        )
+        self.reconnect_interval_sec = float(
+            getattr(self.Config, "reconnect_interval_sec", 2.0)
+        )
+        self.join_timeout_sec = float(getattr(self.Config, "join_timeout_sec", 3.0))
+
+        self.data_input = None
+        self.setting_output = None
+        self._data_lock = Lock()
+        self._last_reconnect_attempt = 0.0
+        self.reconnect_count = 0
+        self.last_exception = ""
+        self.last_exception_time = 0.0
+        self.last_receive_time = 0.0
+        self.last_receive_header: Dict[str, Any] = {}
+
         self.data_input, self.setting_output = self.initialize()
 
         self.data_queue = queue.Queue(maxsize=self.Config.record_quesize)
         self.thread = None
         self.event = None
+        self.warn = False
         self.start()
 
-        self.warn = False
+    def _require_fast_xfftspy(self) -> None:
+        """Fail early when an old tuple-only xfftspy is installed.
+
+        The old ``xfftspy.data_consumer`` creates a Python float tuple for every
+        channel of every board.  At 32768 channels this is too slow and can make
+        the XFFTS FitsWriter side report ``Sending dump ... failed``.  NECST now
+        requires the zero-copy ``return_numpy=True`` data path.
+        """
+
+        try:
+            sig = inspect.signature(xfftspy.data_consumer)
+        except Exception as exc:
+            raise RuntimeError(
+                "Cannot inspect xfftspy.data_consumer; please reinstall the "
+                "updated xfftspy package with return_numpy support."
+            ) from exc
+
+        if "return_numpy" not in sig.parameters:
+            path = getattr(xfftspy, "__file__", "unknown")
+            raise RuntimeError(
+                "Installed xfftspy is too old for NECST XFFTS readout. "
+                "It does not support data_consumer(..., return_numpy=True), "
+                "so it falls back to slow Python tuple spectra and can cause "
+                "XFFTS 'Sending dump failed' errors. "
+                f"Installed xfftspy path: {path}. "
+                "Install the updated xfftspy package before observing."
+            )
+
+    def _configure_data_socket(self, data_input) -> None:
+        sock = getattr(data_input, "sock", None)
+        if sock is None:
+            return
+        try:
+            sock.settimeout(self.data_timeout_sec)
+        except Exception as exc:
+            self.logger.warning(f"Failed to set XFFTS socket timeout: {exc!r}")
+
+    def _open_data_consumer(self):
+        self._require_fast_xfftspy()
+        data_input = xfftspy.data_consumer(
+            self.host,
+            self.data_port,
+            return_numpy=True,
+        )
+        self._configure_data_socket(data_input)
+        return data_input
+
+    def _close_data_consumer(self) -> None:
+        data_input = self.data_input
+        if data_input is None:
+            return
+        try:
+            data_input.close()
+        except Exception:
+            sock = getattr(data_input, "sock", None)
+            if sock is not None:
+                try:
+                    sock.close()
+                except Exception:
+                    pass
+
+    def _clear_data_buffer(self, context: str) -> None:
+        data_input = self.data_input
+        if data_input is None:
+            return
+        try:
+            data_input.clear_buffer()
+        except (socket.timeout, TimeoutError) as exc:
+            # A timeout here is not fatal: it often means START has not produced
+            # enough packets yet.  The read thread will reconnect/report if the
+            # stream remains broken.
+            self._note_exception(f"XFFTS clear_buffer timeout during {context}: {exc!r}")
+        except Exception as exc:
+            self._note_exception(f"XFFTS clear_buffer failed during {context}: {exc!r}")
+
+    def _note_exception(self, message: str) -> None:
+        self.last_exception = str(message)
+        self.last_exception_time = time.time()
+
+    def _reconnect_data_consumer(self, reason: str) -> bool:
+        if (self.event is not None) and self.event.is_set():
+            return False
+        now = time.time()
+        if now - self._last_reconnect_attempt < self.reconnect_interval_sec:
+            return False
+        self._last_reconnect_attempt = now
+
+        with self._data_lock:
+            if (self.event is not None) and self.event.is_set():
+                return False
+            self.logger.warning(f"Reconnecting XFFTS data stream after: {reason}")
+            try:
+                self._close_data_consumer()
+                self.data_input = self._open_data_consumer()
+                self.reconnect_count += 1
+                self._clear_data_buffer("reconnect")
+                return True
+            except Exception as exc:
+                tb = traceback.format_exc()
+                self._note_exception(
+                    f"XFFTS data stream reconnect failed: {exc!r}\n{tb[:500]}"
+                )
+                return False
 
     def start(self) -> None:
         if (self.thread is not None) or (self.event is not None):
-            self.stop()
-        self.thread = Thread(target=self._read_data, daemon=True)
+            self.stop(close_input=False)
         self.event = Event()
+        self.thread = Thread(target=self._read_data, daemon=True)
         self.thread.start()
 
     def _read_data(self) -> None:
@@ -92,28 +222,49 @@ class XFFTS(Spectrometer):
                 self.data_queue.get()
 
             try:
-                data = self.data_input.receive_once()
+                with self._data_lock:
+                    if self.data_input is None:
+                        raise RuntimeError("XFFTS data_consumer is not connected")
+                    data = self.data_input.receive_once()
                 header = data.get("header", {})
                 time_spectrometer = header["timestamp"].decode()
                 try:
                     received_time = float(header.get("received_time", time.time()))
                 except Exception:
                     received_time = time.time()
+                self.last_receive_time = float(received_time)
+                self.last_receive_header = dict(header)
                 self.data_queue.put((received_time, time_spectrometer, data["data"]))
-            except struct.error:
-                exc = traceback.format_exc()
-                self.logger.warning(exc[slice(0, min(len(exc), 100))])
+            except Exception as exc:
+                if (self.event is not None) and self.event.is_set():
+                    break
+                tb = traceback.format_exc()
+                self._note_exception(f"{exc!r}\n{tb[:500]}")
+                self.logger.warning(f"XFFTS data receive failed: {exc!r}")
+                if not self._reconnect_data_consumer(str(exc)):
+                    time.sleep(min(1.0, self.reconnect_interval_sec))
 
-    def stop(self) -> None:
+    def stop(self, *, close_input: bool = True) -> None:
         if self.event is not None:
             self.event.set()
+        if close_input:
+            # Closing the socket unblocks recv(), allowing abort/finalize to return.
+            self._close_data_consumer()
         if self.thread is not None:
-            self.thread.join()
+            self.thread.join(timeout=self.join_timeout_sec)
+            if self.thread.is_alive():
+                self.logger.warning(
+                    "XFFTS reader thread did not stop within "
+                    f"{self.join_timeout_sec:.1f} s"
+                )
         self.event = self.thread = None
         self.warn = False
 
     def initialize(self) -> Tuple[xfftspy.data_consumer, xfftspy.udp_client]:
         """Get configured data input and setting output."""
+        # Fail before starting/reconfiguring hardware if the Python receiver is too old.
+        self._require_fast_xfftspy()
+
         setting_output = xfftspy.udp_client(self.host, self.cmd_port, print=False)
         setting_output.stop()
         setting_output.set_synctime(self.synctime_us)  # synctime in us
@@ -123,23 +274,13 @@ class XFFTS(Spectrometer):
             setting_output.set_board_bandwidth(board_id, bw_mhz)
         setting_output.configure()  # Apply settings
         setting_output.caladc()  # Calibrate ADCs
-        setting_output.start()
 
-        try:
-            data_input = xfftspy.data_consumer(
-                self.host,
-                self.data_port,
-                return_numpy=True,
-            )
-        except TypeError:
-            # Keep compatibility with older xfftspy installations, but warn
-            # because this disables the p17a zero-copy receive fast path.
-            self.logger.warning(
-                "xfftspy.data_consumer does not accept return_numpy=True; "
-                "falling back to tuple spectra"
-            )
-            data_input = xfftspy.data_consumer(self.host, self.data_port)
-        data_input.clear_buffer()
+        # Connect the TCP data consumer before START so the first dumps have a
+        # receiver.  This avoids the common START -> dump 1 failed race.
+        data_input = self._open_data_consumer()
+        self.data_input = data_input
+        setting_output.start()
+        self._clear_data_buffer("initialize")
         return data_input, setting_output
 
     def get_spectra(self) -> Tuple[float, Dict[int, List[float]]]:
@@ -147,6 +288,9 @@ class XFFTS(Spectrometer):
         return self.data_queue.get()
 
     def change_spec_ch(self, chan):
+        # Reconfiguration changes the packet size.  Stop the read thread and
+        # reopen the TCP stream so the next header/data pair is synchronized.
+        self.stop(close_input=True)
         self.setting_output.stop()
         for board in self.bw_mhz.keys():
             self.logger.info(
@@ -154,8 +298,13 @@ class XFFTS(Spectrometer):
             )
             self.setting_output.set_board_numspecchan(board, chan)
         self.setting_output.configure()
+        self.data_input = self._open_data_consumer()
         self.setting_output.start()
+        self._clear_data_buffer("change_spec_ch")
+        self.start()
 
     def finalize(self) -> None:
-        self.setting_output.stop()
-        self.stop()
+        try:
+            self.setting_output.stop()
+        finally:
+            self.stop(close_input=True)


### PR DESCRIPTION
Closes #786

## Summary

- **XFFTS receiver hardening**: add early check for old xfftspy, socket timeout, auto-reconnect, thread-safe data access, and improved stop/join logic
- **Non-blocking Astropy IERS preload**: replace blocking `concurrent.futures` IERS download at import time with a daemon-thread warm-up started after all neclib subpackages are loaded; adds `NECLIB_ASTROPY_IERS_AUTO_DOWNLOAD` env var for offline operation

## Test plan

- [ ] Verify XFFTS recording starts and stops cleanly without "Sending dump failed" errors
- [ ] Verify NECST abort/finalize returns promptly even if XFFTS TCP connection is stalled
- [ ] Verify old xfftspy raises a clear `RuntimeError` at startup
- [ ] Verify `import neclib` completes quickly in offline environments
- [ ] Verify `NECLIB_ASTROPY_IERS_AUTO_DOWNLOAD=0` suppresses remote IERS download