### PR TITLE
simulatorの分光計パケット形式を3要素に統一する

### DIFF
--- a/neclib/devices/spectrometer/ac240.py
+++ b/neclib/devices/spectrometer/ac240.py
@@ -87,7 +87,7 @@ class AC240(Spectrometer):
                 exc = traceback.format_exc()
                 self.logger.warning(exc[slice(0, min(len(exc), 100))])
 
-    def get_spectra(self) -> Tuple[float, Dict[int, List[float]]]:
+    def get_spectra(self) -> Tuple[float, str, Dict[int, List[float]]]:
         self.warn = True
         return self.data_queue.get()
 

--- a/neclib/devices/spectrometer/simulator.py
+++ b/neclib/devices/spectrometer/simulator.py
@@ -16,9 +16,10 @@ class SpectrometerSimulator(Spectrometer):
         initial = [next(_rand) for _ in range(2**15)]
         self._rand = Random().walk(1e10, 1, -1, initial=initial)
 
-    def get_spectra(self) -> Tuple[float, Dict[int, List[float]]]:
-        """Timestamp and dict of spectral data for all boards."""
-        return time.time(), {0: next(self._rand).tolist()}
+    def get_spectra(self) -> Tuple[float, str, Dict[int, List[float]]]:
+        """Return a timestamped synthetic spectrum for all simulated boards."""
+        timestamp = time.time()
+        return timestamp, str(timestamp), {0: next(self._rand).tolist()}
 
     def finalize(self) -> None:
         pass

--- a/neclib/devices/spectrometer/spectrometer_base.py
+++ b/neclib/devices/spectrometer/spectrometer_base.py
@@ -8,8 +8,8 @@ import numpy as np
 
 class Spectrometer(DeviceBase):
     @abstractmethod
-    def get_spectra(self) -> Tuple[float, Dict[int, List[float]]]:
-        """Timestamp and dict of spectral data for all boards."""
+    def get_spectra(self) -> Tuple[float, str, Dict[int, List[float]]]:
+        """Timestamp, spectrometer timestamp, and spectral data for all boards."""
         ...
 
     def calc_tp(self, data: Dict[int, Tuple[float]], tp_range: List[int]) -> dict:

--- a/neclib/devices/spectrometer/xffts.py
+++ b/neclib/devices/spectrometer/xffts.py
@@ -142,7 +142,7 @@ class XFFTS(Spectrometer):
         data_input.clear_buffer()
         return data_input, setting_output
 
-    def get_spectra(self) -> Tuple[float, Dict[int, List[float]]]:
+    def get_spectra(self) -> Tuple[float, str, Dict[int, List[float]]]:
         self.warn = True
         return self.data_queue.get()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ pyerfa = ">=2.0.1,<3.0"
 matplotlib = ">=3.8,<4.0"
 necstdb = { git = "https://github.com/ogawa-ros/necstdb/", tag = "v0.2.10" }
 ogameasure = { git = "https://github.com/ogawa-ros/ogameasure/", tag = "v0.6.3" }
-xfftspy = "^0.2.0"
+xfftspy = "^0.1.3"
 
 # ユーティリティ
 psutil = ">=5.9.4,<8.0"

--- a/tests/devices/spectrometer/test_simulator.py
+++ b/tests/devices/spectrometer/test_simulator.py
@@ -1,0 +1,10 @@
+from neclib.devices.spectrometer.simulator import SpectrometerSimulator
+
+
+def test_spectrometer_simulator_packet_format():
+    timestamp, time_spectrometer, data = SpectrometerSimulator().get_spectra()
+
+    assert isinstance(timestamp, float)
+    assert time_spectrometer == str(timestamp)
+    assert list(data) == [0]
+    assert len(data[0]) == 2**15


### PR DESCRIPTION
## Superseded

このPRは古い `main` を基点として競合しており、現在の `main` では不要な依存変更も含むため、#802 で置き換えます。

Issue: #796
Replacement: #802