### PR TITLE
chore: update xfftspy to 0.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ pyerfa = ">=2.0.1,<3.0"
 matplotlib = ">=3.8,<4.0"
 necstdb = { git = "https://github.com/ogawa-ros/necstdb/", tag = "v0.2.10" }
 ogameasure = { git = "https://github.com/ogawa-ros/ogameasure/", tag = "v0.6.3" }
-xfftspy = "^0.2.0"
+xfftspy = "^0.1.4"
 
 # ユーティリティ
 psutil = ">=5.9.4,<8.0"


### PR DESCRIPTION
## Summary
- correct the `xfftspy` dependency from `^0.2.0` to `^0.1.4`

This follows the xfftspy version correction to `0.1.4`.