### PR TITLE
chore: use Python 3.12 for PyPI publish

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Install dependencies
         run: |
           pip install poetry


### PR DESCRIPTION
## Summary
- update the PyPI release workflow from Python 3.9 to Python 3.12
- keep the existing Actions versions and publish flow unchanged

## Background
`pyproject.toml` requires Python `>=3.12,<3.13`, while the PyPI workflow still configured `actions/setup-python` with Python 3.9. Poetry was falling back to a compatible Python automatically during publish. This change makes the release environment match the project's declared Python requirement directly.