### PR TITLE
#796- Spectrometer simulatorをNECST記録フローに対応

### DIFF
--- a/neclib/defaults/simulator_config.toml
+++ b/neclib/defaults/simulator_config.toml
@@ -113,6 +113,9 @@ synctime_us = 100000
 bw_MHz = { 1 = 2500 }
 max_ch = 32768
 record_quesize = 2
+simulator_t_rx_K = 150.0
+simulator_t_sky_K = 70.0
+simulator_t_hot_K = 293.0
 
 [thermometer]
 _ = ""

--- a/neclib/defaults/simulator_config.toml
+++ b/neclib/defaults/simulator_config.toml
@@ -104,6 +104,16 @@ _ = ""
 [power_meter]
 _ = ""
 
+[spectrometer.xffts]
+_ = "XFFTS"
+host = "localhost"
+data_port = 25144
+cmd_port = 16210
+synctime_us = 100000
+bw_MHz = { 1 = 2500 }
+max_ch = 32768
+record_quesize = 2
+
 [thermometer]
 _ = ""
 

--- a/neclib/devices/spectrometer/ac240.py
+++ b/neclib/devices/spectrometer/ac240.py
@@ -87,7 +87,7 @@ class AC240(Spectrometer):
                 exc = traceback.format_exc()
                 self.logger.warning(exc[slice(0, min(len(exc), 100))])
 
-    def get_spectra(self) -> Tuple[float, Dict[int, List[float]]]:
+    def get_spectra(self) -> Tuple[float, str, Dict[int, List[float]]]:
         self.warn = True
         return self.data_queue.get()
 

--- a/neclib/devices/spectrometer/simulator.py
+++ b/neclib/devices/spectrometer/simulator.py
@@ -1,7 +1,8 @@
 import time
 from typing import Dict, List, Tuple
 
-from ...core.math import Random
+import numpy as np
+
 from .spectrometer_base import Spectrometer
 
 
@@ -14,9 +15,16 @@ class SpectrometerSimulator(Spectrometer):
     def __init__(self) -> None:
         self._max_ch = 2**15
         self._record_ch = self._max_ch
-        _rand = Random(limits=(0, 1e13)).walk(1e10, 1e2, -10)
-        initial = [next(_rand) for _ in range(self._max_ch)]
-        self._rand = Random().walk(1e10, 1, -1, initial=initial)
+
+        # Approximate a spectrometer without attaching any observing-state meaning
+        # to the synthetic data.  ON/OFF/HOT behaviour can be layered on top later.
+        self._baseline = 1e10
+        self._white_noise_fraction = 0.02
+        self._gain = 1.0
+        self._gain_step_sigma = 2e-4
+        self._gain_restore = 0.02
+        self._rng = np.random.default_rng()
+        self._board_scale: Dict[int, float] = {}
 
     @property
     def _board_ids(self) -> List[int]:
@@ -26,12 +34,37 @@ class SpectrometerSimulator(Spectrometer):
             return [0]
         return [int(board_id) for board_id in bw_mhz]
 
+    def _next_gain(self) -> float:
+        """Return slowly varying common gain around unity."""
+        self._gain += self._gain_restore * (1.0 - self._gain)
+        self._gain += float(self._rng.normal(0.0, self._gain_step_sigma))
+        self._gain = float(np.clip(self._gain, 0.98, 1.02))
+        return self._gain
+
+    def _spectrum(self, board_id: int, gain: float) -> List[float]:
+        """Generate broadband noise for one simulated spectrometer board."""
+        if board_id not in self._board_scale:
+            self._board_scale[board_id] = float(self._rng.normal(1.0, 0.01))
+
+        white_noise = self._rng.normal(
+            0.0,
+            self._white_noise_fraction,
+            self._max_ch,
+        )
+        spectrum = (
+            self._baseline
+            * self._board_scale[board_id]
+            * gain
+            * (1.0 + white_noise)
+        )
+        return spectrum[: self._record_ch].tolist()
+
     def get_spectra(self) -> Tuple[float, str, Dict[int, List[float]]]:
         """Return timestamped synthetic spectra for all configured boards."""
         timestamp = time.time()
+        gain = self._next_gain()
         data = {
-            board_id: next(self._rand).tolist()[: self._record_ch]
-            for board_id in self._board_ids
+            board_id: self._spectrum(board_id, gain) for board_id in self._board_ids
         }
         return timestamp, str(timestamp), data
 

--- a/neclib/devices/spectrometer/simulator.py
+++ b/neclib/devices/spectrometer/simulator.py
@@ -16,8 +16,9 @@ class SpectrometerSimulator(Spectrometer):
         self._max_ch = 2**15
         self._record_ch = self._max_ch
 
-        # Approximate a spectrometer without attaching any observing-state meaning
-        # to the synthetic data.  ON/OFF/HOT behaviour can be layered on top later.
+        # Approximate a spectrometer without attaching source-line meaning to the
+        # synthetic data.  ON/OFF line behaviour is intentionally left for a
+        # separate simulator-only extension.
         self._baseline = 1e10
         self._white_noise_fraction = 0.02
         self._gain = 1.0
@@ -25,6 +26,17 @@ class SpectrometerSimulator(Spectrometer):
         self._gain_restore = 0.02
         self._rng = np.random.default_rng()
         self._board_scale: Dict[int, float] = {}
+        self._hot = False
+
+        # These parameters are simulator-only.  The baseline represents the SKY
+        # state, and HOT is scaled by the corresponding total input temperature.
+        self._t_rx_K = float(getattr(self.Config, "simulator_t_rx_K", 150.0))
+        self._t_sky_K = float(getattr(self.Config, "simulator_t_sky_K", 70.0))
+        self._t_hot_K = float(getattr(self.Config, "simulator_t_hot_K", 293.0))
+        if self._t_rx_K < 0 or self._t_sky_K < 0 or self._t_hot_K < 0:
+            raise ValueError("Simulator temperatures must be non-negative")
+        if self._t_rx_K + self._t_sky_K <= 0:
+            raise ValueError("simulator_t_rx_K + simulator_t_sky_K must be positive")
 
     @property
     def _board_ids(self) -> List[int]:
@@ -33,6 +45,15 @@ class SpectrometerSimulator(Spectrometer):
         if not bw_mhz:
             return [0]
         return [int(board_id) for board_id in bw_mhz]
+
+    @property
+    def hot_factor(self) -> float:
+        """Return HOT/SKY power ratio for the configured simulator temperatures."""
+        return (self._t_rx_K + self._t_hot_K) / (self._t_rx_K + self._t_sky_K)
+
+    def set_hot(self, enabled: bool) -> None:
+        """Select the simulator-only HOT-load state."""
+        self._hot = bool(enabled)
 
     def _next_gain(self) -> float:
         """Return slowly varying common gain around unity."""
@@ -51,10 +72,12 @@ class SpectrometerSimulator(Spectrometer):
             self._white_noise_fraction,
             self._max_ch,
         )
+        load_scale = self.hot_factor if self._hot else 1.0
         spectrum = (
             self._baseline
             * self._board_scale[board_id]
             * gain
+            * load_scale
             * (1.0 + white_noise)
         )
         return spectrum[: self._record_ch].tolist()

--- a/neclib/devices/spectrometer/simulator.py
+++ b/neclib/devices/spectrometer/simulator.py
@@ -12,14 +12,26 @@ class SpectrometerSimulator(Spectrometer):
     is_simulator = True
 
     def __init__(self) -> None:
+        self._max_ch = 2**15
+        self._record_ch = self._max_ch
         _rand = Random(limits=(0, 1e13)).walk(1e10, 1e2, -10)
-        initial = [next(_rand) for _ in range(2**15)]
+        initial = [next(_rand) for _ in range(self._max_ch)]
         self._rand = Random().walk(1e10, 1, -1, initial=initial)
 
     def get_spectra(self) -> Tuple[float, str, Dict[int, List[float]]]:
         """Return a timestamped synthetic spectrum for the simulated board."""
         timestamp = time.time()
-        return timestamp, str(timestamp), {0: next(self._rand).tolist()}
+        spectrum = next(self._rand).tolist()[: self._record_ch]
+        return timestamp, str(timestamp), {0: spectrum}
+
+    def change_spec_ch(self, chan: int) -> None:
+        """Change the number of channels returned by the simulated spectrometer."""
+        chan = int(chan)
+        if not 1 <= chan <= self._max_ch:
+            raise ValueError(
+                f"Simulated spectrometer channel count must be 1-{self._max_ch}: {chan}"
+            )
+        self._record_ch = chan
 
     def finalize(self) -> None:
         pass

--- a/neclib/devices/spectrometer/simulator.py
+++ b/neclib/devices/spectrometer/simulator.py
@@ -18,11 +18,22 @@ class SpectrometerSimulator(Spectrometer):
         initial = [next(_rand) for _ in range(self._max_ch)]
         self._rand = Random().walk(1e10, 1, -1, initial=initial)
 
+    @property
+    def _board_ids(self) -> List[int]:
+        """Return board IDs enabled by the bound spectrometer configuration."""
+        bw_mhz = getattr(self.Config, "bw_MHz", None)
+        if not bw_mhz:
+            return [0]
+        return [int(board_id) for board_id in bw_mhz]
+
     def get_spectra(self) -> Tuple[float, str, Dict[int, List[float]]]:
-        """Return a timestamped synthetic spectrum for the simulated board."""
+        """Return timestamped synthetic spectra for all configured boards."""
         timestamp = time.time()
-        spectrum = next(self._rand).tolist()[: self._record_ch]
-        return timestamp, str(timestamp), {0: spectrum}
+        data = {
+            board_id: next(self._rand).tolist()[: self._record_ch]
+            for board_id in self._board_ids
+        }
+        return timestamp, str(timestamp), data
 
     def change_spec_ch(self, chan: int) -> None:
         """Change the number of channels returned by the simulated spectrometer."""

--- a/neclib/devices/spectrometer/simulator.py
+++ b/neclib/devices/spectrometer/simulator.py
@@ -16,9 +16,10 @@ class SpectrometerSimulator(Spectrometer):
         initial = [next(_rand) for _ in range(2**15)]
         self._rand = Random().walk(1e10, 1, -1, initial=initial)
 
-    def get_spectra(self) -> Tuple[float, Dict[int, List[float]]]:
-        """Timestamp and dict of spectral data for all boards."""
-        return time.time(), {0: next(self._rand).tolist()}
+    def get_spectra(self) -> Tuple[float, str, Dict[int, List[float]]]:
+        """Return a timestamped synthetic spectrum for the simulated board."""
+        timestamp = time.time()
+        return timestamp, str(timestamp), {0: next(self._rand).tolist()}
 
     def finalize(self) -> None:
         pass

--- a/neclib/devices/spectrometer/spectrometer_base.py
+++ b/neclib/devices/spectrometer/spectrometer_base.py
@@ -8,8 +8,8 @@ import numpy as np
 
 class Spectrometer(DeviceBase):
     @abstractmethod
-    def get_spectra(self) -> Tuple[float, Dict[int, List[float]]]:
-        """Timestamp and dict of spectral data for all boards."""
+    def get_spectra(self) -> Tuple[float, str, Dict[int, List[float]]]:
+        """Timestamp, spectrometer timestamp, and spectral data for all boards."""
         ...
 
     def calc_tp(self, data: Dict[int, Tuple[float]], tp_range: List[int]) -> dict:

--- a/neclib/devices/spectrometer/xffts.py
+++ b/neclib/devices/spectrometer/xffts.py
@@ -29,7 +29,7 @@ class XFFTS(Spectrometer):
         transmmition. The default value of this device is 25144.
 
     cmd_port : str
-        Ethernet port of using devices. This port is used for command
+        Ethernet port  of using devices. This port is used for command
         operation. The default value of this device is 16210.
 
     synctime_us : int

--- a/neclib/devices/spectrometer/xffts.py
+++ b/neclib/devices/spectrometer/xffts.py
@@ -29,7 +29,7 @@ class XFFTS(Spectrometer):
         transmmition. The default value of this device is 25144.
 
     cmd_port : str
-        Ethernet port  of using devices. This port is used for command
+        Ethernet port of using devices. This port is used for command
         operation. The default value of this device is 16210.
 
     synctime_us : int
@@ -142,7 +142,7 @@ class XFFTS(Spectrometer):
         data_input.clear_buffer()
         return data_input, setting_output
 
-    def get_spectra(self) -> Tuple[float, Dict[int, List[float]]]:
+    def get_spectra(self) -> Tuple[float, str, Dict[int, List[float]]]:
         self.warn = True
         return self.data_queue.get()
 

--- a/tests/devices/spectrometer/test_simulator.py
+++ b/tests/devices/spectrometer/test_simulator.py
@@ -1,3 +1,8 @@
+import tomllib
+from pathlib import Path
+
+import neclib
+
 from neclib.devices.spectrometer.simulator import SpectrometerSimulator
 
 
@@ -9,3 +14,13 @@ def test_spectrometer_simulator_packet_format():
     assert list(data) == [0]
     assert isinstance(data[0], list)
     assert len(data[0]) == 2**15
+
+
+def test_default_simulator_config_enables_spectrometer():
+    config_path = Path(neclib.__file__).parent / "defaults" / "simulator_config.toml"
+    with config_path.open("rb") as file:
+        simulator_config = tomllib.load(file)
+
+    assert simulator_config["simulator"] is True
+    assert simulator_config["spectrometer"]["xffts"]["_"] == "XFFTS"
+    assert simulator_config["spectrometer"]["xffts"]["max_ch"] == 2**15

--- a/tests/devices/spectrometer/test_simulator.py
+++ b/tests/devices/spectrometer/test_simulator.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import neclib
+import numpy as np
 
 from neclib.devices.spectrometer.simulator import SpectrometerSimulator
 
@@ -42,6 +43,27 @@ def test_spectrometer_simulator_channel_binning():
         assert all(len(spectrum) == 1024 for spectrum in data.values())
     finally:
         spectrometer.change_spec_ch(2**15)
+
+
+def test_spectrometer_simulator_total_power_varies_over_time():
+    spectrometer = SpectrometerSimulator()
+    original_config = SpectrometerSimulator.Config
+    SpectrometerSimulator.Config = SimpleNamespace(bw_MHz={"1": 2500})
+
+    # Keep this regression test deterministic while exercising the same random model.
+    spectrometer._rng = np.random.default_rng(0)
+    spectrometer._gain = 1.0
+    spectrometer._board_scale = {}
+
+    try:
+        total_powers = []
+        for _ in range(5):
+            _, _, data = spectrometer.get_spectra()
+            total_powers.append(np.float32(np.nansum(data[1])))
+
+        assert len(set(total_powers)) > 1
+    finally:
+        SpectrometerSimulator.Config = original_config
 
 
 def test_default_simulator_config_enables_spectrometer():

--- a/tests/devices/spectrometer/test_simulator.py
+++ b/tests/devices/spectrometer/test_simulator.py
@@ -66,11 +66,45 @@ def test_spectrometer_simulator_total_power_varies_over_time():
         SpectrometerSimulator.Config = original_config
 
 
+def test_spectrometer_simulator_hot_load_scales_broadband_power():
+    original_config = SpectrometerSimulator.Config
+    SpectrometerSimulator.Config = SimpleNamespace(
+        bw_MHz={"1": 2500},
+        simulator_t_rx_K=150.0,
+        simulator_t_sky_K=70.0,
+        simulator_t_hot_K=293.0,
+    )
+
+    try:
+        spectrometer = SpectrometerSimulator()
+        spectrometer._rng = np.random.default_rng(0)
+        spectrometer._gain_step_sigma = 0.0
+        spectrometer._board_scale = {1: 1.0}
+
+        spectrometer.set_hot(False)
+        _, _, sky_data = spectrometer.get_spectra()
+        sky_power = float(np.nansum(sky_data[1]))
+
+        spectrometer.set_hot(True)
+        _, _, hot_data = spectrometer.get_spectra()
+        hot_power = float(np.nansum(hot_data[1]))
+
+        expected = (150.0 + 293.0) / (150.0 + 70.0)
+        assert np.isclose(spectrometer.hot_factor, expected)
+        assert np.isclose(hot_power / sky_power, expected, rtol=0.01)
+    finally:
+        SpectrometerSimulator.Config = original_config
+
+
 def test_default_simulator_config_enables_spectrometer():
     config_path = Path(neclib.__file__).parent / "defaults" / "simulator_config.toml"
     with config_path.open("rb") as file:
         simulator_config = tomllib.load(file)
 
     assert simulator_config["simulator"] is True
-    assert simulator_config["spectrometer"]["xffts"]["_"] == "XFFTS"
-    assert simulator_config["spectrometer"]["xffts"]["max_ch"] == 2**15
+    xffts = simulator_config["spectrometer"]["xffts"]
+    assert xffts["_"] == "XFFTS"
+    assert xffts["max_ch"] == 2**15
+    assert xffts["simulator_t_rx_K"] == 150.0
+    assert xffts["simulator_t_sky_K"] == 70.0
+    assert xffts["simulator_t_hot_K"] == 293.0

--- a/tests/devices/spectrometer/test_simulator.py
+++ b/tests/devices/spectrometer/test_simulator.py
@@ -1,5 +1,6 @@
 import tomllib
 from pathlib import Path
+from types import SimpleNamespace
 
 import neclib
 
@@ -18,12 +19,27 @@ def test_spectrometer_simulator_packet_format():
     assert len(data[0]) == 2**15
 
 
+def test_spectrometer_simulator_uses_configured_boards():
+    spectrometer = SpectrometerSimulator()
+    original_config = SpectrometerSimulator.Config
+    SpectrometerSimulator.Config = SimpleNamespace(
+        bw_MHz={"1": 2500, "2": 2500, "3": 2500, "4": 2500}
+    )
+
+    try:
+        _, _, data = spectrometer.get_spectra()
+        assert list(data) == [1, 2, 3, 4]
+        assert all(len(spectrum) == 2**15 for spectrum in data.values())
+    finally:
+        SpectrometerSimulator.Config = original_config
+
+
 def test_spectrometer_simulator_channel_binning():
     spectrometer = SpectrometerSimulator()
     try:
         spectrometer.change_spec_ch(1024)
         _, _, data = spectrometer.get_spectra()
-        assert len(data[0]) == 1024
+        assert all(len(spectrum) == 1024 for spectrum in data.values())
     finally:
         spectrometer.change_spec_ch(2**15)
 

--- a/tests/devices/spectrometer/test_simulator.py
+++ b/tests/devices/spectrometer/test_simulator.py
@@ -7,13 +7,25 @@ from neclib.devices.spectrometer.simulator import SpectrometerSimulator
 
 
 def test_spectrometer_simulator_packet_format():
-    timestamp, time_spectrometer, data = SpectrometerSimulator().get_spectra()
+    spectrometer = SpectrometerSimulator()
+    spectrometer.change_spec_ch(2**15)
+    timestamp, time_spectrometer, data = spectrometer.get_spectra()
 
     assert isinstance(timestamp, float)
     assert time_spectrometer == str(timestamp)
     assert list(data) == [0]
     assert isinstance(data[0], list)
     assert len(data[0]) == 2**15
+
+
+def test_spectrometer_simulator_channel_binning():
+    spectrometer = SpectrometerSimulator()
+    try:
+        spectrometer.change_spec_ch(1024)
+        _, _, data = spectrometer.get_spectra()
+        assert len(data[0]) == 1024
+    finally:
+        spectrometer.change_spec_ch(2**15)
 
 
 def test_default_simulator_config_enables_spectrometer():

--- a/tests/devices/spectrometer/test_simulator.py
+++ b/tests/devices/spectrometer/test_simulator.py
@@ -1,0 +1,11 @@
+from neclib.devices.spectrometer.simulator import SpectrometerSimulator
+
+
+def test_spectrometer_simulator_packet_format():
+    timestamp, time_spectrometer, data = SpectrometerSimulator().get_spectra()
+
+    assert isinstance(timestamp, float)
+    assert time_spectrometer == str(timestamp)
+    assert list(data) == [0]
+    assert isinstance(data[0], list)
+    assert len(data[0]) == 2**15


### PR DESCRIPTION
## 概要

Closes #796

NECSTの `simulator = true` 環境で、実機XFFTSなしに分光計ノードと記録処理を動かせるようにします。

関連: necst-telescope/necst#506 / PR #507

## 原因

NECST側は分光計packetを次の3要素として展開します。

```python
timestamp, time_spectrometer, data = packet
```

XFFTS/AC240も実際には3要素をqueueへ格納していますが、`SpectrometerSimulator.get_spectra()` だけが2要素 `(timestamp, data)` を返していたため、Simulatorでは次の例外で停止していました。

```text
ValueError: not enough values to unpack (expected 3, got 2)
```

また、標準 `simulator_config.toml` にspectrometer定義がなく、標準Simulator設定だけでは分光計Simulatorが記録経路に入りませんでした。

## 変更内容

- `SpectrometerSimulator.get_spectra()` を `(timestamp, time_spectrometer, data)` の3要素へ変更
- `Spectrometer` 基底インターフェースを3要素packetの型へ更新
- XFFTS / AC240 の `get_spectra()` 型ヒントを実装と一致させる
- Simulatorに `change_spec_ch()` を実装し、legacy channel binning時も実機driverと同じ呼び出し経路を通せるようにする
- Simulatorが `bw_MHz` に定義されたboard IDを使用するように変更
  - 例: `bw_MHz = { 1 = 2500, 2 = 2500, 3 = 2500, 4 = 2500 }` の場合、Board 1〜4の疑似スペクトルを返す
  - 設定を持たないSimulator単体利用時のみ後方互換としてBoard 0を使用
- ラベル未指定時の疑似スペクトルを、ほぼ一定値のrandom walkから分光計らしいノイズへ変更
  - 約 `1e10` のbaseline
  - channelごとのwhite noise
  - 全boardに共通するゆっくりしたgain変動
  - boardごとの固定された小さな感度差
  - TPへ変換して `float32` になった後も時系列変動が残るようにする
- Simulator専用HOT load状態を追加
  - `set_hot(True/False)` でのみ切り替える
  - 実機XFFTS driverにはHOT処理を追加しない
  - `HOT / SKY = (T_rx + T_hot) / (T_rx + T_sky)` で全channelを広帯域にスケール
  - `simulator_t_rx_K = 150`, `simulator_t_sky_K = 70`, `simulator_t_hot_K = 293` を既定値とし、約2.01倍
- `simulator_config.toml` に `[spectrometer.xffts]` を追加
  - `_ = "XFFTS"` を指定し、`simulator = true` による `SpectrometerSimulator` への置換を利用
  - 32768 ch設定で実機なしの疑似スペクトル経路を有効化
  - Simulator専用温度設定を追加
- Simulator packet形式、設定board ID、channel binning、TP時間変動、HOT/SKY強度比、標準Simulator configの回帰テストを追加

## 期待する確認

Simulator環境で `ros2 run necst record` を起動した際に、従来の2要素packetによる `ValueError` が発生せず、設定された各boardの疑似32768 chスペクトルをNECST側へ渡せること。

Quick Look等でTPを時系列表示した際に、Simulatorでも完全な一定値ではなくノイズ・gain変動に伴う揺らぎが確認できること。

necst PR #507と組み合わせると、chopperがinsert位置へ到達した期間だけHOT/SKY温度比に応じて広帯域強度が上昇すること。

観測側からchannel数変更が送られた場合も、Simulatorが指定channel数の疑似スペクトルを返すこと。

## 補足

ON / OFFラベルに応じたGaussian lineは本PRでは実装しません。将来ON信号を実装する際は、SkydipでもON相当ラベルが使われるため、ONラベルだけを根拠にGaussianを生成しない設計とします。

既存PR #797 は古い `main` を基点として競合しており、現在不要な `xfftspy` 依存変更も含んでいたため、本PRで置き換えます。本PRでは依存関係を変更していません。