### PR TITLE
#803- SpectrometerSimulatorにON Gaussian line生成を追加

### DIFF
--- a/neclib/defaults/simulator_config.toml
+++ b/neclib/defaults/simulator_config.toml
@@ -117,6 +117,13 @@ simulator_t_rx_K = 150.0
 simulator_t_sky_K = 70.0
 simulator_t_hot_K = 293.0
 
+# Simulator source-line settings are keyed by recording_window_setup window_id.
+# NECST resolves each window to its raw board and full-channel position.
+[spectrometer.simulator.on_line.12CO_J2_1]
+v_center_kms = -7.0
+fwhm_kms = 3.0
+t_line_peak_K = 20.0
+
 [thermometer]
 _ = ""
 

--- a/neclib/defaults/simulator_config.toml
+++ b/neclib/defaults/simulator_config.toml
@@ -117,13 +117,6 @@ simulator_t_rx_K = 150.0
 simulator_t_sky_K = 70.0
 simulator_t_hot_K = 293.0
 
-# Simulator source-line settings are keyed by recording_window_setup window_id.
-# NECST resolves each window to its raw board and full-channel position.
-[spectrometer.simulator.on_line.12CO_J2_1]
-v_center_kms = -7.0
-fwhm_kms = 3.0
-t_line_peak_K = 20.0
-
 [thermometer]
 _ = ""
 

--- a/neclib/devices/spectrometer/simulator.py
+++ b/neclib/devices/spectrometer/simulator.py
@@ -1,5 +1,6 @@
+import math
 import time
-from typing import Dict, List, Tuple
+from typing import Dict, List, Mapping, Sequence, Tuple
 
 import numpy as np
 
@@ -16,9 +17,9 @@ class SpectrometerSimulator(Spectrometer):
         self._max_ch = 2**15
         self._record_ch = self._max_ch
 
-        # Approximate a spectrometer without attaching source-line meaning to the
-        # synthetic data.  ON/OFF line behaviour is intentionally left for a
-        # separate simulator-only extension.
+        # Approximate a spectrometer while keeping all source-state behaviour
+        # simulator-only.  NECST decides *when* the observation is ON/OFF/HOT and
+        # passes already resolved channel-domain line components to this class.
         self._baseline = 1e10
         self._white_noise_fraction = 0.02
         self._gain = 1.0
@@ -27,9 +28,12 @@ class SpectrometerSimulator(Spectrometer):
         self._rng = np.random.default_rng()
         self._board_scale: Dict[int, float] = {}
         self._hot = False
+        self._on_source = False
+        self._on_line_components: Dict[int, List[Dict[str, float]]] = {}
+        self._channel_index = np.arange(self._max_ch, dtype=float)
 
         # These parameters are simulator-only.  The baseline represents the SKY
-        # state, and HOT is scaled by the corresponding total input temperature.
+        # state, and HOT/ON are expressed as additional input temperature.
         self._t_rx_K = float(getattr(self.Config, "simulator_t_rx_K", 150.0))
         self._t_sky_K = float(getattr(self.Config, "simulator_t_sky_K", 70.0))
         self._t_hot_K = float(getattr(self.Config, "simulator_t_hot_K", 293.0))
@@ -55,6 +59,52 @@ class SpectrometerSimulator(Spectrometer):
         """Select the simulator-only HOT-load state."""
         self._hot = bool(enabled)
 
+    def set_on_source(self, enabled: bool) -> None:
+        """Enable or disable source-line emission for simulator ON integrations."""
+        self._on_source = bool(enabled)
+
+    def set_on_line_components(
+        self, components_by_board: Mapping[int, Sequence[Mapping[str, float]]]
+    ) -> None:
+        """Replace simulator ON-line components in full-channel coordinates.
+
+        Parameters
+        ----------
+        components_by_board
+            Mapping from raw board ID to Gaussian components.  Each component
+            contains ``center_channel`` (fractional full-channel index),
+            ``fwhm_channels`` (> 0), and ``t_line_peak_K`` (>= 0).
+
+        Notes
+        -----
+        This interface deliberately knows nothing about ROS, window IDs, rest
+        frequencies, velocity frames, or LO chains.  NECST resolves those
+        observation-level concepts before calling this method.
+        """
+        normalized: Dict[int, List[Dict[str, float]]] = {}
+        for raw_board_id, raw_components in components_by_board.items():
+            board_id = int(raw_board_id)
+            board_components: List[Dict[str, float]] = []
+            for raw in raw_components:
+                center = float(raw["center_channel"])
+                fwhm = float(raw["fwhm_channels"])
+                peak = float(raw["t_line_peak_K"])
+                if not math.isfinite(center):
+                    raise ValueError("center_channel must be finite")
+                if not math.isfinite(fwhm) or fwhm <= 0:
+                    raise ValueError("fwhm_channels must be positive finite")
+                if not math.isfinite(peak) or peak < 0:
+                    raise ValueError("t_line_peak_K must be non-negative finite")
+                board_components.append(
+                    {
+                        "center_channel": center,
+                        "fwhm_channels": fwhm,
+                        "t_line_peak_K": peak,
+                    }
+                )
+            normalized[board_id] = board_components
+        self._on_line_components = normalized
+
     def _next_gain(self) -> float:
         """Return slowly varying common gain around unity."""
         self._gain += self._gain_restore * (1.0 - self._gain)
@@ -62,8 +112,33 @@ class SpectrometerSimulator(Spectrometer):
         self._gain = float(np.clip(self._gain, 0.98, 1.02))
         return self._gain
 
+    def _line_temperature(self, board_id: int) -> np.ndarray:
+        """Return summed ON-line antenna temperature for one raw board."""
+        line_temperature = np.zeros(self._max_ch, dtype=float)
+        for component in self._on_line_components.get(int(board_id), []):
+            center = component["center_channel"]
+            fwhm = component["fwhm_channels"]
+            peak = component["t_line_peak_K"]
+            line_temperature += peak * np.exp(
+                -4.0
+                * math.log(2.0)
+                * ((self._channel_index - center) / fwhm) ** 2
+            )
+        return line_temperature
+
+    def _load_scale(self, board_id: int):
+        """Return channel-wise input-temperature scale relative to SKY."""
+        if self._hot:
+            # The inserted load blocks the sky, so a stale ON state must never
+            # superpose an astronomical line on the HOT spectrum.
+            return self.hot_factor
+        if not self._on_source:
+            return 1.0
+        line_temperature = self._line_temperature(board_id)
+        return 1.0 + line_temperature / (self._t_rx_K + self._t_sky_K)
+
     def _spectrum(self, board_id: int, gain: float) -> List[float]:
-        """Generate broadband noise for one simulated spectrometer board."""
+        """Generate broadband noise and simulator-only state signal for one board."""
         if board_id not in self._board_scale:
             self._board_scale[board_id] = float(self._rng.normal(1.0, 0.01))
 
@@ -72,12 +147,11 @@ class SpectrometerSimulator(Spectrometer):
             self._white_noise_fraction,
             self._max_ch,
         )
-        load_scale = self.hot_factor if self._hot else 1.0
         spectrum = (
             self._baseline
             * self._board_scale[board_id]
             * gain
-            * load_scale
+            * self._load_scale(board_id)
             * (1.0 + white_noise)
         )
         return spectrum[: self._record_ch].tolist()

--- a/neclib/devices/spectrometer/simulator.py
+++ b/neclib/devices/spectrometer/simulator.py
@@ -19,7 +19,7 @@ class SpectrometerSimulator(Spectrometer):
 
         # Approximate a spectrometer while keeping all source-state behaviour
         # simulator-only.  NECST decides *when* the observation is ON/OFF/HOT and
-        # passes already resolved channel-domain line components to this class.
+        # passes already resolved velocity axes to this class.
         self._baseline = 1e10
         self._white_noise_fraction = 0.02
         self._gain = 1.0
@@ -29,8 +29,7 @@ class SpectrometerSimulator(Spectrometer):
         self._board_scale: Dict[int, float] = {}
         self._hot = False
         self._on_source = False
-        self._on_line_components: Dict[int, List[Dict[str, float]]] = {}
-        self._channel_index = np.arange(self._max_ch, dtype=float)
+        self._on_line_components: Dict[int, List[Dict[str, object]]] = {}
 
         # These parameters are simulator-only.  The baseline represents the SKY
         # state, and HOT/ON are expressed as additional input temperature.
@@ -64,41 +63,50 @@ class SpectrometerSimulator(Spectrometer):
         self._on_source = bool(enabled)
 
     def set_on_line_components(
-        self, components_by_board: Mapping[int, Sequence[Mapping[str, float]]]
+        self, components_by_board: Mapping[int, Sequence[Mapping[str, object]]]
     ) -> None:
-        """Replace simulator ON-line components in full-channel coordinates.
+        """Replace simulator ON-line components resolved by NECST.
 
         Parameters
         ----------
         components_by_board
             Mapping from raw board ID to Gaussian components.  Each component
-            contains ``center_channel`` (fractional full-channel index),
-            ``fwhm_channels`` (> 0), and ``t_line_peak_K`` (>= 0).
+            contains a full-channel ``velocity_axis_kms`` and physical
+            ``v_center_kms``, ``fwhm_kms`` (> 0), ``t_line_peak_K`` (>= 0).
 
         Notes
         -----
         This interface deliberately knows nothing about ROS, window IDs, rest
         frequencies, velocity frames, or LO chains.  NECST resolves those
-        observation-level concepts before calling this method.
+        observation-level concepts and supplies the velocity coordinate itself.
         """
-        normalized: Dict[int, List[Dict[str, float]]] = {}
+        normalized: Dict[int, List[Dict[str, object]]] = {}
         for raw_board_id, raw_components in components_by_board.items():
             board_id = int(raw_board_id)
-            board_components: List[Dict[str, float]] = []
+            board_components: List[Dict[str, object]] = []
             for raw in raw_components:
-                center = float(raw["center_channel"])
-                fwhm = float(raw["fwhm_channels"])
+                velocity_axis = np.asarray(raw["velocity_axis_kms"], dtype=float)
+                center = float(raw["v_center_kms"])
+                fwhm = float(raw["fwhm_kms"])
                 peak = float(raw["t_line_peak_K"])
+                if velocity_axis.ndim != 1 or len(velocity_axis) != self._max_ch:
+                    raise ValueError(
+                        "velocity_axis_kms must be a one-dimensional full-channel "
+                        f"axis of length {self._max_ch}"
+                    )
+                if not np.all(np.isfinite(velocity_axis)):
+                    raise ValueError("velocity_axis_kms must contain only finite values")
                 if not math.isfinite(center):
-                    raise ValueError("center_channel must be finite")
+                    raise ValueError("v_center_kms must be finite")
                 if not math.isfinite(fwhm) or fwhm <= 0:
-                    raise ValueError("fwhm_channels must be positive finite")
+                    raise ValueError("fwhm_kms must be positive finite")
                 if not math.isfinite(peak) or peak < 0:
                     raise ValueError("t_line_peak_K must be non-negative finite")
                 board_components.append(
                     {
-                        "center_channel": center,
-                        "fwhm_channels": fwhm,
+                        "velocity_axis_kms": velocity_axis.copy(),
+                        "v_center_kms": center,
+                        "fwhm_kms": fwhm,
                         "t_line_peak_K": peak,
                     }
                 )
@@ -116,13 +124,14 @@ class SpectrometerSimulator(Spectrometer):
         """Return summed ON-line antenna temperature for one raw board."""
         line_temperature = np.zeros(self._max_ch, dtype=float)
         for component in self._on_line_components.get(int(board_id), []):
-            center = component["center_channel"]
-            fwhm = component["fwhm_channels"]
-            peak = component["t_line_peak_K"]
+            velocity_axis = component["velocity_axis_kms"]
+            center = float(component["v_center_kms"])
+            fwhm = float(component["fwhm_kms"])
+            peak = float(component["t_line_peak_K"])
             line_temperature += peak * np.exp(
                 -4.0
                 * math.log(2.0)
-                * ((self._channel_index - center) / fwhm) ** 2
+                * ((velocity_axis - center) / fwhm) ** 2
             )
         return line_temperature
 

--- a/tests/devices/spectrometer/test_simulator.py
+++ b/tests/devices/spectrometer/test_simulator.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import neclib
 import numpy as np
+import pytest
 
 from neclib.devices.spectrometer.simulator import SpectrometerSimulator
 
@@ -82,6 +83,7 @@ def test_spectrometer_simulator_hot_load_scales_broadband_power():
         spectrometer._board_scale = {1: 1.0}
 
         spectrometer.set_hot(False)
+        spectrometer.set_on_source(False)
         _, _, sky_data = spectrometer.get_spectra()
         sky_power = float(np.nansum(sky_data[1]))
 
@@ -93,7 +95,154 @@ def test_spectrometer_simulator_hot_load_scales_broadband_power():
         assert np.isclose(spectrometer.hot_factor, expected)
         assert np.isclose(hot_power / sky_power, expected, rtol=0.01)
     finally:
+        spectrometer.set_hot(False)
         SpectrometerSimulator.Config = original_config
+
+
+def test_spectrometer_simulator_on_adds_gaussian_line_only_when_enabled():
+    spectrometer = SpectrometerSimulator()
+    original_config = SpectrometerSimulator.Config
+    SpectrometerSimulator.Config = SimpleNamespace(bw_MHz={"1": 2500})
+
+    old_white_noise = spectrometer._white_noise_fraction
+    old_gain_step = spectrometer._gain_step_sigma
+    try:
+        spectrometer._white_noise_fraction = 0.0
+        spectrometer._gain_step_sigma = 0.0
+        spectrometer._gain = 1.0
+        spectrometer._board_scale = {1: 1.0}
+        spectrometer.set_hot(False)
+        spectrometer.set_on_line_components(
+            {
+                1: [
+                    {
+                        "center_channel": 1000.0,
+                        "fwhm_channels": 20.0,
+                        "t_line_peak_K": 22.0,
+                    }
+                ]
+            }
+        )
+
+        spectrometer.set_on_source(False)
+        _, _, off_data = spectrometer.get_spectra()
+        spectrometer.set_on_source(True)
+        _, _, on_data = spectrometer.get_spectra()
+
+        off = np.asarray(off_data[1])
+        on = np.asarray(on_data[1])
+        expected_peak_ratio = 1.0 + 22.0 / (150.0 + 70.0)
+
+        assert np.isclose(on[1000] / off[1000], expected_peak_ratio)
+        assert np.isclose(on[2000] / off[2000], 1.0)
+    finally:
+        spectrometer.set_on_source(False)
+        spectrometer.set_on_line_components({})
+        spectrometer._white_noise_fraction = old_white_noise
+        spectrometer._gain_step_sigma = old_gain_step
+        SpectrometerSimulator.Config = original_config
+
+
+def test_spectrometer_simulator_supports_multiple_lines_on_same_board():
+    spectrometer = SpectrometerSimulator()
+    original_config = SpectrometerSimulator.Config
+    SpectrometerSimulator.Config = SimpleNamespace(bw_MHz={"1": 2500})
+
+    old_white_noise = spectrometer._white_noise_fraction
+    old_gain_step = spectrometer._gain_step_sigma
+    try:
+        spectrometer._white_noise_fraction = 0.0
+        spectrometer._gain_step_sigma = 0.0
+        spectrometer._gain = 1.0
+        spectrometer._board_scale = {1: 1.0}
+        spectrometer.set_hot(False)
+        spectrometer.set_on_line_components(
+            {
+                1: [
+                    {
+                        "center_channel": 1000.0,
+                        "fwhm_channels": 10.0,
+                        "t_line_peak_K": 20.0,
+                    },
+                    {
+                        "center_channel": 2000.0,
+                        "fwhm_channels": 30.0,
+                        "t_line_peak_K": 5.0,
+                    },
+                ]
+            }
+        )
+        spectrometer.set_on_source(True)
+
+        _, _, data = spectrometer.get_spectra()
+        spectrum = np.asarray(data[1])
+        baseline = spectrometer._baseline
+
+        assert spectrum[1000] > baseline
+        assert spectrum[2000] > baseline
+        assert spectrum[1000] > spectrum[2000]
+    finally:
+        spectrometer.set_on_source(False)
+        spectrometer.set_on_line_components({})
+        spectrometer._white_noise_fraction = old_white_noise
+        spectrometer._gain_step_sigma = old_gain_step
+        SpectrometerSimulator.Config = original_config
+
+
+def test_spectrometer_simulator_hot_suppresses_on_line():
+    spectrometer = SpectrometerSimulator()
+    original_config = SpectrometerSimulator.Config
+    SpectrometerSimulator.Config = SimpleNamespace(bw_MHz={"1": 2500})
+
+    old_white_noise = spectrometer._white_noise_fraction
+    old_gain_step = spectrometer._gain_step_sigma
+    try:
+        spectrometer._white_noise_fraction = 0.0
+        spectrometer._gain_step_sigma = 0.0
+        spectrometer._gain = 1.0
+        spectrometer._board_scale = {1: 1.0}
+        spectrometer.set_on_line_components(
+            {
+                1: [
+                    {
+                        "center_channel": 1000.0,
+                        "fwhm_channels": 20.0,
+                        "t_line_peak_K": 100.0,
+                    }
+                ]
+            }
+        )
+        spectrometer.set_on_source(True)
+        spectrometer.set_hot(True)
+
+        _, _, data = spectrometer.get_spectra()
+        spectrum = np.asarray(data[1])
+
+        assert np.isclose(spectrum[1000], spectrum[2000])
+    finally:
+        spectrometer.set_hot(False)
+        spectrometer.set_on_source(False)
+        spectrometer.set_on_line_components({})
+        spectrometer._white_noise_fraction = old_white_noise
+        spectrometer._gain_step_sigma = old_gain_step
+        SpectrometerSimulator.Config = original_config
+
+
+def test_spectrometer_simulator_rejects_invalid_line_component():
+    spectrometer = SpectrometerSimulator()
+
+    with pytest.raises(ValueError, match="fwhm_channels"):
+        spectrometer.set_on_line_components(
+            {
+                1: [
+                    {
+                        "center_channel": 1000.0,
+                        "fwhm_channels": 0.0,
+                        "t_line_peak_K": 10.0,
+                    }
+                ]
+            }
+        )
 
 
 def test_default_simulator_config_enables_spectrometer():

--- a/tests/devices/spectrometer/test_simulator.py
+++ b/tests/devices/spectrometer/test_simulator.py
@@ -270,10 +270,3 @@ def test_default_simulator_config_enables_spectrometer():
     assert xffts["simulator_t_rx_K"] == 150.0
     assert xffts["simulator_t_sky_K"] == 70.0
     assert xffts["simulator_t_hot_K"] == 293.0
-
-    on_line = simulator_config["spectrometer"]["simulator"]["on_line"]
-    assert on_line["12CO_J2_1"] == {
-        "v_center_kms": -7.0,
-        "fwhm_kms": 3.0,
-        "t_line_peak_K": 20.0,
-    }

--- a/tests/devices/spectrometer/test_simulator.py
+++ b/tests/devices/spectrometer/test_simulator.py
@@ -257,3 +257,10 @@ def test_default_simulator_config_enables_spectrometer():
     assert xffts["simulator_t_rx_K"] == 150.0
     assert xffts["simulator_t_sky_K"] == 70.0
     assert xffts["simulator_t_hot_K"] == 293.0
+
+    on_line = simulator_config["spectrometer"]["simulator"]["on_line"]
+    assert on_line["12CO_J2_1"] == {
+        "v_center_kms": -7.0,
+        "fwhm_kms": 3.0,
+        "t_line_peak_K": 20.0,
+    }

--- a/tests/devices/spectrometer/test_simulator.py
+++ b/tests/devices/spectrometer/test_simulator.py
@@ -104,6 +104,8 @@ def test_spectrometer_simulator_on_adds_gaussian_line_only_when_enabled():
     original_config = SpectrometerSimulator.Config
     SpectrometerSimulator.Config = SimpleNamespace(bw_MHz={"1": 2500})
 
+    velocity_axis = np.linspace(-100.0, 100.0, 2**15)
+    center = float(velocity_axis[1000])
     old_white_noise = spectrometer._white_noise_fraction
     old_gain_step = spectrometer._gain_step_sigma
     try:
@@ -116,8 +118,9 @@ def test_spectrometer_simulator_on_adds_gaussian_line_only_when_enabled():
             {
                 1: [
                     {
-                        "center_channel": 1000.0,
-                        "fwhm_channels": 20.0,
+                        "velocity_axis_kms": velocity_axis,
+                        "v_center_kms": center,
+                        "fwhm_kms": 10.0,
                         "t_line_peak_K": 22.0,
                     }
                 ]
@@ -134,7 +137,7 @@ def test_spectrometer_simulator_on_adds_gaussian_line_only_when_enabled():
         expected_peak_ratio = 1.0 + 22.0 / (150.0 + 70.0)
 
         assert np.isclose(on[1000] / off[1000], expected_peak_ratio)
-        assert np.isclose(on[2000] / off[2000], 1.0)
+        assert np.isclose(on[-1] / off[-1], 1.0)
     finally:
         spectrometer.set_on_source(False)
         spectrometer.set_on_line_components({})
@@ -148,6 +151,9 @@ def test_spectrometer_simulator_supports_multiple_lines_on_same_board():
     original_config = SpectrometerSimulator.Config
     SpectrometerSimulator.Config = SimpleNamespace(bw_MHz={"1": 2500})
 
+    velocity_axis = np.linspace(-100.0, 100.0, 2**15)
+    center1 = float(velocity_axis[1000])
+    center2 = float(velocity_axis[2000])
     old_white_noise = spectrometer._white_noise_fraction
     old_gain_step = spectrometer._gain_step_sigma
     try:
@@ -160,13 +166,15 @@ def test_spectrometer_simulator_supports_multiple_lines_on_same_board():
             {
                 1: [
                     {
-                        "center_channel": 1000.0,
-                        "fwhm_channels": 10.0,
+                        "velocity_axis_kms": velocity_axis,
+                        "v_center_kms": center1,
+                        "fwhm_kms": 1.0,
                         "t_line_peak_K": 20.0,
                     },
                     {
-                        "center_channel": 2000.0,
-                        "fwhm_channels": 30.0,
+                        "velocity_axis_kms": velocity_axis,
+                        "v_center_kms": center2,
+                        "fwhm_kms": 1.0,
                         "t_line_peak_K": 5.0,
                     },
                 ]
@@ -194,6 +202,8 @@ def test_spectrometer_simulator_hot_suppresses_on_line():
     original_config = SpectrometerSimulator.Config
     SpectrometerSimulator.Config = SimpleNamespace(bw_MHz={"1": 2500})
 
+    velocity_axis = np.linspace(-100.0, 100.0, 2**15)
+    center = float(velocity_axis[1000])
     old_white_noise = spectrometer._white_noise_fraction
     old_gain_step = spectrometer._gain_step_sigma
     try:
@@ -205,8 +215,9 @@ def test_spectrometer_simulator_hot_suppresses_on_line():
             {
                 1: [
                     {
-                        "center_channel": 1000.0,
-                        "fwhm_channels": 20.0,
+                        "velocity_axis_kms": velocity_axis,
+                        "v_center_kms": center,
+                        "fwhm_kms": 10.0,
                         "t_line_peak_K": 100.0,
                     }
                 ]
@@ -218,7 +229,7 @@ def test_spectrometer_simulator_hot_suppresses_on_line():
         _, _, data = spectrometer.get_spectra()
         spectrum = np.asarray(data[1])
 
-        assert np.isclose(spectrum[1000], spectrum[2000])
+        assert np.isclose(spectrum[1000], spectrum[-1])
     finally:
         spectrometer.set_hot(False)
         spectrometer.set_on_source(False)
@@ -230,14 +241,16 @@ def test_spectrometer_simulator_hot_suppresses_on_line():
 
 def test_spectrometer_simulator_rejects_invalid_line_component():
     spectrometer = SpectrometerSimulator()
+    velocity_axis = np.linspace(-100.0, 100.0, 2**15)
 
-    with pytest.raises(ValueError, match="fwhm_channels"):
+    with pytest.raises(ValueError, match="fwhm_kms"):
         spectrometer.set_on_line_components(
             {
                 1: [
                     {
-                        "center_channel": 1000.0,
-                        "fwhm_channels": 0.0,
+                        "velocity_axis_kms": velocity_axis,
+                        "v_center_kms": 0.0,
+                        "fwhm_kms": 0.0,
                         "t_line_peak_K": 10.0,
                     }
                 ]


### PR DESCRIPTION
## 概要

Closes #803

HOT対応を含む `#796-spectrometer-simulator` をbaseに、SpectrometerSimulatorへON sourceのGaussian line生成を追加します。

依存: necst-telescope/necst#509

## レイヤー分離

neclibはROS、ON/OFF観測ラベル、`window_id`、rest frequency、LO chainを扱いません。

NECST側で解決済みのcomponentだけをSimulator専用APIへ渡します。

```text
board_id
velocity_axis_kms[full channel]
v_center_kms
fwhm_kms
t_line_peak_K
```

実機XFFTS driverには変更を入れていません。

## Gaussian

各componentについて速度空間で直接

```text
T_line(v) = T_peak * exp[-4 ln(2) ((v-v_center)/FWHM)^2]
```

を評価します。channel幅へ近似変換せず、`v_center_kms` と `fwhm_kms` をそのまま物理量として使います。

## 状態

- OFF/SKY: baselineのみ
- ON: `T_rx + T_sky + T_line(v)` 相当にlineを加算
- HOT: `T_rx + T_hot` を優先し、ON stateが残っていてもlineは重畳しない
- 1 boardに複数componentを設定可能

## Test

- ON時のみGaussianが現れる
- OFFではlineなし
- 同一boardの複数lineを加算できる
- HOT中はON lineを抑止する
- 不正なFWHMを拒否する

## 補足

特定のNECST `window_id` はneclib default configに持ち込みません。signalのwindow設定とboard/velocity axis解決はNECST #508 / PR #509側の責務です。